### PR TITLE
'preferredUsername' from the keycloak session, not tokenID

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 * -text
 *.java text
 *.md text
+*.rake text
 *.xml text
 *.yaml text
 *.yml text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.93:
+* in `ReplicantSecuredSessionManagerImpl`, use the `PreferredUsename` claim as the UserID associated with the
+  Replicant Session, rather than the TokenID. The TokenID will change each time the token refreshes. An
+  alternative is the `Subject` token but everywhere this is deployed also adds the claim `PreferredUsename`
+  which is easier to read. Submitted by James Walker.
+
 ## 0.5.92:
 * Use GWT super-source feature to replace `FilterUtil`.
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'buildr', '= 1.5.3'
+gem 'zapwhite', '= 2.8.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'buildr', '= 1.5.3'
 gem 'zapwhite', '= 2.8.0'
+gem 'mcrt', '= 1.4.0'

--- a/server/src/main/java/org/realityforge/replicant/server/transport/ReplicantSecuredSessionManagerImpl.java
+++ b/server/src/main/java/org/realityforge/replicant/server/transport/ReplicantSecuredSessionManagerImpl.java
@@ -19,7 +19,8 @@ public abstract class ReplicantSecuredSessionManagerImpl
   protected ReplicantSession newReplicantSession()
   {
     final OidcKeycloakAccount account = getAuthService().findAccount();
-    final String userID = null == account ? null : account.getKeycloakSecurityContext().getToken().getId();
+    final String userID =
+      null == account ? null : account.getKeycloakSecurityContext().getToken().getPreferredUsername();
     final String sessionID = UUID.randomUUID().toString();
     return new ReplicantSession( userID, sessionID );
   }

--- a/tasks/publish.rake
+++ b/tasks/publish.rake
@@ -1,0 +1,16 @@
+require 'mcrt'
+
+desc 'Publish release on maven central'
+task 'publish_to_maven_central' do
+  project = Buildr.projects[0].root_project
+  password = ENV['MAVEN_CENTRAL_PASSWORD'] || (raise "Unable to locate environment variable with name 'MAVEN_CENTRAL_PASSWORD'")
+  MavenCentralPublishTool.buildr_release(project, 'org.realityforge', 'realityforge', password)
+end
+
+desc 'Publish release to maven central iff current HEAD is a tag'
+task 'publish_if_tagged' do
+  version = `git describe --exact-match --tags 2>&1`
+  if 0 == $?.exitstatus && version =~ /^v[0-9]/
+    task('publish_to_maven_central').invoke
+  end
+end


### PR DESCRIPTION
 Use the PreferredUsename as the UserID associated with the Replicant Session, rather than the TokenID.

TokenID will change each time the token refreshes.
Alterantive would be using the token Subject - which is a UUID that appears to map 1:1 to the preferred username.
Gone with preferredUsername for readability at this time.