### PR TITLE
Expose idle status

### DIFF
--- a/client-common/src/main/java/org/realityforge/replicant/client/runtime/ContextConverger.java
+++ b/client-common/src/main/java/org/realityforge/replicant/client/runtime/ContextConverger.java
@@ -31,6 +31,8 @@ public interface ContextConverger
 
   boolean isConvergeComplete();
 
+  boolean isIdle();
+
   /**
    * Pause the converger for the duration of the action.
    */

--- a/client-common/src/main/java/org/realityforge/replicant/client/runtime/ContextConvergerImpl.java
+++ b/client-common/src/main/java/org/realityforge/replicant/client/runtime/ContextConvergerImpl.java
@@ -92,6 +92,13 @@ public abstract class ContextConvergerImpl
     return _convergeComplete;
   }
 
+  @Override
+  public boolean isIdle()
+  {
+    return isConvergeComplete() &&
+           getReplicantClientSystem().getDataLoaders().stream().allMatch( dl -> dl.getService().isIdle() );
+  }
+
   enum ConvergeAction
   {
     SUBMITTED_ADD,    // The submission has been added to the AOI queue

--- a/client-common/src/main/java/org/realityforge/replicant/client/transport/AbstractDataLoaderService.java
+++ b/client-common/src/main/java/org/realityforge/replicant/client/transport/AbstractDataLoaderService.java
@@ -1059,8 +1059,8 @@ public abstract class AbstractDataLoaderService
         }
       }
     }
-    onDataLoadComplete( status );
     _currentAction = null;
+    onDataLoadComplete( status );
     if ( null != _resetAction )
     {
       _resetAction.run();

--- a/client-common/src/main/java/org/realityforge/replicant/client/transport/AbstractDataLoaderService.java
+++ b/client-common/src/main/java/org/realityforge/replicant/client/transport/AbstractDataLoaderService.java
@@ -647,6 +647,13 @@ public abstract class AbstractDataLoaderService
                                                          @Nonnull Consumer<Runnable> failAction );
 
   @Override
+  public boolean isIdle()
+  {
+    return _currentAoiActions.isEmpty() && _currentAction == null &&
+    _session.getPendingActions().isEmpty() && _session.getPendingAreaOfInterestActions().isEmpty();
+  }
+
+  @Override
   public boolean isSubscribed( @Nonnull final ChannelDescriptor descriptor )
   {
     return null != getSubscriptionManager().findSubscription( descriptor );

--- a/client-common/src/main/java/org/realityforge/replicant/client/transport/DataLoaderService.java
+++ b/client-common/src/main/java/org/realityforge/replicant/client/transport/DataLoaderService.java
@@ -85,6 +85,11 @@ public interface DataLoaderService
   boolean isSubscribed( @Nonnull ChannelDescriptor descriptor );
 
   /**
+   * Return true if the DataLoader has nothing outstanding to complete
+   */
+  boolean isIdle();
+
+  /**
    * Return true if an area of interest action with specified parameters is pending or being processed.
    * When the action parameter is DELETE the filter parameter is ignored.
    */

--- a/client-common/src/test/java/org/realityforge/replicant/client/runtime/TestDataLoaderService.java
+++ b/client-common/src/test/java/org/realityforge/replicant/client/runtime/TestDataLoaderService.java
@@ -108,6 +108,12 @@ final class TestDataLoaderService
     return false;
   }
 
+  @Override
+  public boolean isIdle()
+  {
+    return true;
+  }
+
   @Nullable
   @Override
   public ClientSession getSession()

--- a/client-common/src/test/java/org/realityforge/replicant/client/transport/DataLoaderServiceTest.java
+++ b/client-common/src/test/java/org/realityforge/replicant/client/transport/DataLoaderServiceTest.java
@@ -880,7 +880,9 @@ public class DataLoaderServiceTest
     assertEquals( service.getCurrentAOIActions().size(), 0 );
     assertEquals( service.ensureSession().getPendingAreaOfInterestActions().size(), 0 );
 
-    when( sm.findSubscription( eq( channelA3 ) ) ).thenReturn( new ChannelSubscriptionEntry( channelA3, "boo", false ) );
+    when( sm.findSubscription( eq( channelA3 ) ) ).thenReturn( new ChannelSubscriptionEntry( channelA3,
+                                                                                             "boo",
+                                                                                             false ) );
 
     service.requestUnsubscribe( channelA1 );
     service.requestUnsubscribe( channelA2 );
@@ -890,6 +892,52 @@ public class DataLoaderServiceTest
     assertEquals( service.progressAreaOfInterestActions(), true );
     assertEquals( service.getCurrentAOIActions().size(), 0 );
     assertEquals( service.ensureSession().getPendingAreaOfInterestActions().size(), 0 );
+  }
+
+  @Test
+  public void isIdle()
+    throws Exception
+  {
+    final TestChangeSet changeSet1 =
+      new TestChangeSet( 1,
+                         mock( Runnable.class ),
+                         new Change[ 0 ],
+                         new ChannelAction[ 0 ] );
+    final TestDataLoadService service = newService( new TestChangeSet[]{ changeSet1 }, true );
+    configureService( service );
+
+    assertTrue( service.isIdle() );
+
+    final ChannelDescriptor channelA1 = new ChannelDescriptor( TestGraph.A, 1 );
+
+    // Have pending AOI
+    service.requestSubscribe( channelA1, null );
+    assertTrue( service.getCurrentAOIActions().isEmpty() );
+    assertFalse( service.isIdle() );
+
+    // Have current AOI
+    service.progressAreaOfInterestActions();
+    assertFalse( service.getCurrentAOIActions().isEmpty() );
+    assertFalse( service.isIdle() );
+
+    // Back to idle
+    completeOutstandingAOIs( service );
+    assertTrue( service.isIdle() );
+
+    // Have pending Action
+    service.ensureSession().enqueueDataLoad( "jsonData" );
+    assertNull( service.getCurrentAction() );
+    assertFalse( service.isIdle() );
+
+    // Have current Action
+    configureRequests( service, service.getChangeSets() );
+    service.progressDataLoad();
+    assertNotNull( service.getCurrentAction() );
+    assertFalse( service.isIdle() );
+
+    // Back to idle
+    progressWorkTillDone( service, 6, 1 );
+    assertTrue( service.isIdle() );
   }
 
   private void completeOutstandingAOIs( final TestDataLoadService service )


### PR DESCRIPTION
Allows users to provide feedback based on the 'running state' of replicant