### PR TITLE
Make AreaOfInterestEntry public.

### DIFF
--- a/client-common/src/main/java/org/realityforge/replicant/client/transport/AreaOfInterestEntry.java
+++ b/client-common/src/main/java/org/realityforge/replicant/client/transport/AreaOfInterestEntry.java
@@ -6,7 +6,7 @@ import javax.annotation.Nullable;
 import org.realityforge.replicant.client.ChannelDescriptor;
 import org.realityforge.replicant.client.FilterUtil;
 
-final class AreaOfInterestEntry
+final public class AreaOfInterestEntry
 {
   @Nonnull
   private final String _systemKey;

--- a/client-common/src/main/java/org/realityforge/replicant/client/transport/AreaOfInterestEntry.java
+++ b/client-common/src/main/java/org/realityforge/replicant/client/transport/AreaOfInterestEntry.java
@@ -6,7 +6,7 @@ import javax.annotation.Nullable;
 import org.realityforge.replicant.client.ChannelDescriptor;
 import org.realityforge.replicant.client.FilterUtil;
 
-final public class AreaOfInterestEntry
+public final class AreaOfInterestEntry
 {
   @Nonnull
   private final String _systemKey;


### PR DESCRIPTION
It's exposed by AbstractDataLoaderService#getCurrentAOIActions, and containers try to create a proxy for this method and may do for subclasses that are outside the transport package